### PR TITLE
Allow to use link fields on list page

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ class MemberAdmin(AdminChangeLinksMixin, admin.ModelAdmin):
     list_display = ['name', 'group_link']
     change_links = [
         ('group', {
-            'admin_order_field': 'name',  # Allow to sort group_link column by group__name field
+            'admin_order_field': 'group__name',  # Allow to sort members by group_link column, using group__name field
         })
     ]
 ```

--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ class MemberAdmin(AdminChangeLinksMixin, admin.ModelAdmin):
     change_links = ['group']  # Just specify the name of the `ForeignKey` field
 ```
 
+It is possible to show links on admin *list page* as well:
+
+```python
+@admin.register(Member)
+class MemberAdmin(AdminChangeLinksMixin, admin.ModelAdmin):
+    list_display = ['name', 'group_link']  # Show link to group *change page* on member *list page*
+    change_links = ['group']  # Just specify the name of the `ForeignKey` field
+```
+
 
 ### Extra options
 
@@ -65,6 +74,18 @@ class GroupAdmin(AdminChangeLinksMixin, admin.ModelAdmin):
             'label': 'All members',  # Used as label for the link
             'model': 'Member',  # Specify a different model, you can also specify an app using `app.Member`
             'lookup_filter': 'user_group'  # Specify the GET parameter used for filtering the queryset
+        })
+    ]
+```
+
+For showing links on list page, such extra options can be useful:
+```python
+@admin.register(Group)
+class MemberAdmin(AdminChangeLinksMixin, admin.ModelAdmin):
+    list_display = ['name', 'group_link']
+    change_links = [
+        ('group', {
+            'admin_order_field': 'name',  # Allow to sort group_link column by group__name field
         })
     ]
 ```


### PR DESCRIPTION
I think it is useful to show link fields on admin **list page** as well, not only on **change page**.

To do it, we can just add `<field>_link` to `list_display`.
But currently, it is not possible, because new functions (that renders our links) are added only when `get_readonly_fields()` method is called. But django expect, that such functions exists in ModelAdmin instance after init, even before `get_readonly_fields()`. It applies some checks to validate fields from `list_display`, and they fail without current patch.

Example of error:
> The value of 'list_display[2]' refers to 'created_by_link', which is not a callable, an attribute of 'MyModelAdmin', or an attribute or method on 'my_app.MyModel'.